### PR TITLE
fix: tests (yaml indentation)

### DIFF
--- a/integration_test/bulk_import_test.go
+++ b/integration_test/bulk_import_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Import test", func() {
 			Expect(stdOut).To(ContainSubstring(`value: gx4ll8193j5rw0wljgqo`))
 			Expect(stdOut).To(ContainSubstring(`
 metadata:
-  some: metadata`))
+    some: metadata`))
 
 			session = RunCommand("get", "-n", "/director/deployment/blobstore-director1-with-metadata")
 			Eventually(session).Should(Exit(0))

--- a/integration_test/json_test.go
+++ b/integration_test/json_test.go
@@ -10,7 +10,7 @@ import (
 var _ = Describe("json secrets", func() {
 	credentialName := GenerateUniqueCredentialName()
 	credentialValue := `{"object":{"is":"complex"},"has":["an","array"]}`
-	credentialYaml := "value:\n  has:\n  - an\n  - array\n  object:\n    is: complex\n"
+	credentialYaml := "value:\n    has:\n        - an\n        - array\n    object:\n        is: complex\n"
 
 	It("should set, get, and delete a new json secret", func() {
 		By("setting a new json secret", func() {

--- a/integration_test/metadata_test.go
+++ b/integration_test/metadata_test.go
@@ -27,7 +27,7 @@ var _ = It("should generate a new secret with and without metadata", func() {
 		Expect(stdOut).To(ContainSubstring(`type: password`))
 		Expect(stdOut).To(ContainSubstring(`
 metadata:
-  some: metadata
+    some: metadata
 `))
 	})
 
@@ -121,7 +121,7 @@ var _ = It("should regenerate a secret with and without metadata", func() {
 		Expect(stdOut).To(ContainSubstring(`type: password`))
 		Expect(stdOut).To(ContainSubstring(`
 metadata:
-  some: regenerated-metadata
+    some: regenerated-metadata
 `))
 	})
 
@@ -215,7 +215,7 @@ var _ = It("should set a new secret with and without metadata", func() {
 		Expect(stdOut).To(ContainSubstring(`type: value`))
 		Expect(stdOut).To(ContainSubstring(`
 metadata:
-  some: metadata
+    some: metadata
 `))
 	})
 

--- a/integration_test/permission_test.go
+++ b/integration_test/permission_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Permission Test", func() {
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring("actor: " + actor))
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring("path: " + path))
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring(`operations:
-- read
-- write`))
+    - read
+    - write`))
 			})
 		})
 		Context("Set Permission is called on permission that exists", func() {
@@ -90,8 +90,8 @@ var _ = Describe("Permission Test", func() {
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring("actor: " + actor))
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring("path: " + path))
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring(`operations:
-- read
-- write`))
+    - read
+    - write`))
 			})
 		})
 	})
@@ -134,8 +134,8 @@ var _ = Describe("Permission Test", func() {
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring("actor: " + actor))
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring("path: " + path))
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring(`operations:
-- read
-- write`))
+    - read
+    - write`))
 			})
 		})
 	})
@@ -159,8 +159,8 @@ var _ = Describe("Permission Test", func() {
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring("actor: " + actor))
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring("path: " + path))
 				Eventually(string(session.Out.Contents())).Should(ContainSubstring(`operations:
-- read
-- write`))
+    - read
+    - write`))
 			})
 		})
 	})


### PR DESCRIPTION
- based on this change: https://github.com/cloudfoundry/credhub-cli/pull/124/files it looks like the yaml output from credhub cli is now different; so these tests are now failing (e.:
https://tpe-concourse-rock.acc.broadcom.net/teams/identity-and-credentials/pipelines/credhub-edge/jobs/test-mysql-integration-jammy/builds/364)
- fix by adjusting the indentation like the credhub-cli tests do